### PR TITLE
Bump min SDK version to 9

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:required="false" />
 
     <uses-sdk
-        android:minSdkVersion="7"
+        android:minSdkVersion="9"
         android:targetSdkVersion="23" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,4 @@
 APP_ABI := armeabi-v7a arm64-v8a armeabi mips mips64 x86 x86_64
-APP_PLATFORM := android-8
+APP_PLATFORM := android-9
 APP_OPTIM := release
 APP_CFLAGS := -DHAVE_CONFIG_H


### PR DESCRIPTION
to avoid issues with newer Android NDK.

android-ndk-r10d works without it,
but android-ndk-r12b produces broken libraries
witout atod, srand, rand, signal and so on.
